### PR TITLE
笔误校正 (#179)

### DIFF
--- a/doc/mobmall.md
+++ b/doc/mobmall.md
@@ -12,7 +12,7 @@ litemall轻商城，是商城移动版本。
   * babel-polyfill
   * @xkeshi/vue-countdown
   * Vant
-* 轻商城前端，即litemall-wx-api模块，也就是和小商城后端是一样的。
+* 轻商城后端，即litemall-wx-api模块，也就是和小商城后端是一样的。
   * Spring Boot 2.x
   * Spring MVC
   * [weixin-java-tools](https://gitee.com/binary/weixin-java-tools)


### PR DESCRIPTION
15行 ```* 轻商城前端，即litemall-wx-api模块``` 改为 ```* 轻商城后端，即litemall-wx-api模块```