### PR TITLE
修复了用户订单列表点击去支付无法正常跳转 (#252)

### DIFF
--- a/litemall-vue/src/views/user/order-list/index.vue
+++ b/litemall-vue/src/views/user/order-list/index.vue
@@ -42,7 +42,7 @@
               <van-button size="small"
                           v-if="el.handleOption.pay"
                           type="danger"
-                          @click="toPay(el.id)">去支付</van-button>
+                          @click.stop="toPay(el.id)">去支付</van-button>
               <van-button size="small"
                           v-if="el.handleOption.refund"
                           type="danger"


### PR DESCRIPTION
* Update index.vue

修复了商品分类无法切换的bug

* Update index.vue

阻止冒泡事件，修复了点击去支付后跳转到支付页面又执行上层列表点击事件跳到订单详情页面